### PR TITLE
Add 'class_embed' to assertion values

### DIFF
--- a/ldm/models/diffusion/SDSeg.py
+++ b/ldm/models/diffusion/SDSeg.py
@@ -2180,7 +2180,7 @@ class DiffusionWrapper(pl.LightningModule):
         super().__init__()
         self.diffusion_model = instantiate_from_config(diff_model_config)
         self.conditioning_key = conditioning_key
-        assert self.conditioning_key in [None, 'concat', 'crossattn', 'hybrid', 'adm']
+        assert self.conditioning_key in [None, 'concat', 'crossattn', 'hybrid', 'adm', 'class_embed']
 
     def forward(self, x, t, c_concat: list = None, c_crossattn: list = None):
         if self.conditioning_key is None:


### PR DESCRIPTION
Problem encountered while running the code for multiclass segmentation similar to synapse dataset : Assertion error as conditioning_key 'class_embed' was not added to the assertion matching values. Added 'class_embed' to the set of values to ensure new version of the code works for multiclass dataset. This issue might have been only present in the new version.